### PR TITLE
Twilio Chat Service -- WIP (Do Not Merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Session.vim
 lib/
 
 coverage
+.vscode

--- a/example/app.js
+++ b/example/app.js
@@ -4,39 +4,104 @@ const socketio = require('feathers-socketio');
 const bodyParser = require('body-parser');
 const errorHandler = require('feathers-errors/handler');
 const smsService = require('../lib').sms;
+const chatService = require('../lib').chat;
 
 // Create a feathers instance.
 var app = feathers()
-// Enable REST services
+  // Enable REST services
   .configure(rest())
   // Enable Socket.io services
   .configure(socketio())
   // Turn on JSON parser for REST services
   .use(bodyParser.json())
   // Turn on URL-encoded parser for REST services
-  .use(bodyParser.urlencoded({extended: true}));
+  .use(bodyParser.urlencoded({ extended: true }));
 
-app.use('/twilio/sms', smsService({
-  accountSid: 'your acount sid',
-  authToken: 'your auth token' // ex. your.domain.com
-}));
+app.use(
+  '/twilio/sms',
+  smsService({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token' // ex. your.domain.com
+  })
+);
 
 // Send an email!
-app.service('twilio/sms').create({
-  from: '+15005550006', // Your Twilio SMS capable phone number
-  to: '+15551234567',
-  body: 'Twilio test'
-}).then(function (result) {
-  console.log('Sent SMS', result);
-}).catch(err => {
-  console.log(err);
-});
+app
+  .service('twilio/sms')
+  .create({
+    from: '+15005550006', // Your Twilio SMS capable phone number
+    to: '+15551234567',
+    body: 'Twilio test'
+  })
+  .then(function(result) {
+    console.log('Sent SMS', result);
+  })
+  .catch(err => {
+    console.log(err);
+  });
+
+// chat services
+app.use(
+  '/twilio/chat/token',
+  chatService.token({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token',
+    serviceSid: 'you chat service sid',
+    signingKeySid: 'you signing key sid',
+    signingKeySecret: 'you signing key secret'
+  })
+);
+
+app.use(
+  '/twilio/chat/users',
+  chatService.users({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token',
+    serviceSid: 'you chat service sid'
+  })
+);
+
+app.use(
+  '/twilio/chat/roles',
+  chatService.roles({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token',
+    serviceSid: 'you chat service sid'
+  })
+);
+
+app.use(
+  '/twilio/chat/channels',
+  chatService.channels({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token',
+    serviceSid: 'you chat service sid'
+  })
+);
+
+app.use(
+  '/twilio/chat/channels/:channelId/members',
+  chatService.members({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token',
+    serviceSid: 'you chat service sid'
+  })
+);
+
+app.use(
+  '/twilio/chat/channels/:channelId/messages',
+  chatService.messages({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token',
+    serviceSid: 'you chat service sid'
+  })
+);
 
 app.use(errorHandler());
 
 // Start the server.
 const port = 3030;
 
-app.listen(port, function () {
+app.listen(port, function() {
   console.log(`Feathers server listening on port ${port}`);
 });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "feathers-errors": "^2.0.1",
     "sinon-as-promised": "^4.0.0",
     "sinon-chai": "^2.8.0",
-    "twilio": "^2.11.0"
+    "twilio": "^3.9.1"
   },
   "devDependencies": {
     "async": "^1.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
-if (!global._babelPolyfill) { require('babel-polyfill'); }
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}
 
 import call from './services/call';
 import sms from './services/sms';
+import * as chat from './services/chat';
 
-export default { call, sms };
+export default { call, sms, chat };

--- a/src/services/chat/channels.js
+++ b/src/services/chat/channels.js
@@ -1,0 +1,63 @@
+import Twilio from 'twilio';
+import removeCircular from '../utils/removeCircular';
+
+export default class TwilioChatChannels {
+  constructor(options = {}) {
+    if (!options.accountSid) {
+      throw new Error('Twilio `accountSid` needs to be provided');
+    }
+
+    if (!options.authToken) {
+      throw new Error('Twilio `authToken` needs to be provided');
+    }
+
+    if (!options.serviceSid) {
+      throw new Error('Twilio `serviceSid` needs to be provided');
+    }
+
+    this.options = options;
+
+    const twilio = new Twilio(options.accountSid, options.authToken);
+    this.client = twilio.chat.services(options.serviceSid);
+  }
+
+  find() {
+    return this.client.channels
+      .list(this.options.paginate)
+      .then(removeCircular);
+  }
+
+  get(id) {
+    return this.client
+      .channels(id)
+      .fetch()
+      .then(removeCircular);
+  }
+
+  create(data) {
+    const { uniqueName, friendlyName, attributes, type = 'private' } = data;
+    return this.client.channels
+      .create({
+        uniqueName,
+        friendlyName,
+        attributes,
+        type
+      })
+      .then(removeCircular);
+  }
+
+  patch(id, data) {
+    const { uniqueName, friendlyName, attributes } = data;
+    return this.client
+      .channels(id)
+      .update({ uniqueName, friendlyName, attributes })
+      .then(removeCircular);
+  }
+
+  remove(id) {
+    return this.client
+      .channels(id)
+      .remove()
+      .then(removeCircular);
+  }
+}

--- a/src/services/chat/index.js
+++ b/src/services/chat/index.js
@@ -1,0 +1,6 @@
+export { default as token } from './token';
+export { default as users } from './users';
+export { default as roles } from './roles';
+export { default as channels } from './channels';
+export { default as members } from './members';
+export { default as messages } from './messages';

--- a/src/services/chat/members.js
+++ b/src/services/chat/members.js
@@ -1,0 +1,58 @@
+import Twilio from 'twilio';
+import removeCircular from '../utils/removeCircular';
+
+export default class TwilioChatMembers {
+  constructor(options = {}) {
+    if (!options.accountSid) {
+      throw new Error('Twilio `accountSid` needs to be provided');
+    }
+
+    if (!options.authToken) {
+      throw new Error('Twilio `authToken` needs to be provided');
+    }
+
+    if (!options.serviceSid) {
+      throw new Error('Twilio `serviceSid` needs to be provided');
+    }
+
+    this.options = options;
+
+    const twilio = new Twilio(options.accountSid, options.authToken);
+    this.client = twilio.chat.services(options.serviceSid);
+  }
+
+  find(params) {
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .members.list(this.options.paginate)
+      .then(removeCircular);
+  }
+
+  get(id, params) {
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .members(id)
+      .fetch()
+      .then(removeCircular);
+  }
+
+  create(data, params) {
+    const { identity, roleSid } = data;
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .members.create({ identity, roleSid })
+      .then(removeCircular);
+  }
+
+  remove(id, params) {
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .members(id)
+      .remove()
+      .then(removeCircular);
+  }
+}

--- a/src/services/chat/messages.js
+++ b/src/services/chat/messages.js
@@ -1,0 +1,68 @@
+import Twilio from 'twilio';
+import removeCircular from '../utils/removeCircular';
+
+export default class TwilioChatMessages {
+  constructor(options = {}) {
+    if (!options.accountSid) {
+      throw new Error('Twilio `accountSid` needs to be provided');
+    }
+
+    if (!options.authToken) {
+      throw new Error('Twilio `authToken` needs to be provided');
+    }
+
+    if (!options.serviceSid) {
+      throw new Error('Twilio `serviceSid` needs to be provided');
+    }
+
+    this.options = options;
+
+    const twilio = new Twilio(options.accountSid, options.authToken);
+    this.client = twilio.chat.services(options.serviceSid);
+  }
+
+  find(params) {
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .messages.list(this.options.paginate)
+      .then(sanitize);
+  }
+
+  get(id, params) {
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .messages(id)
+      .fetch()
+      .then(sanitize);
+  }
+
+  create(data, params) {
+    const { body, attributes, from } = data;
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .messages.create({ body, attributes, from })
+      .then(sanitize);
+  }
+
+  patch(id, data, params) {
+    const { body, attributes } = data;
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .messages(id)
+      .update({ body, attributes })
+      .then(sanitize);
+  }
+
+  remove(id, params) {
+    const { channelId } = params;
+    return this.client
+      .channels(channelId)
+      .messages(id)
+      .remove()
+      .then(sanitize);
+  }
+}

--- a/src/services/chat/roles.js
+++ b/src/services/chat/roles.js
@@ -1,0 +1,56 @@
+import Twilio from 'twilio';
+import removeCircular from '../utils/removeCircular';
+
+export default class TwilioChatRoles {
+  constructor(options = {}) {
+    if (!options.accountSid) {
+      throw new Error('Twilio `accountSid` needs to be provided');
+    }
+
+    if (!options.authToken) {
+      throw new Error('Twilio `authToken` needs to be provided');
+    }
+
+    if (!options.serviceSid) {
+      throw new Error('Twilio `serviceSid` needs to be provided');
+    }
+
+    this.options = options;
+
+    const twilio = new Twilio(options.accountSid, options.authToken);
+    this.client = twilio.chat.services(options.serviceSid);
+  }
+
+  find() {
+    return this.client.roles.list(this.options.paginate).then(removeCircular);
+  }
+
+  get(id) {
+    return this.client
+      .roles(id)
+      .fetch()
+      .then(removeCircular);
+  }
+
+  create(data) {
+    const { friendlyName, type, permission } = data;
+    return this.client.roles
+      .create({ friendlyName, type, permission })
+      .then(removeCircular);
+  }
+
+  patch(id, data) {
+    const { permission } = data;
+    return this.client
+      .roles(id)
+      .update({ permission })
+      .then(removeCircular);
+  }
+
+  remove(id) {
+    return this.client
+      .roles(id)
+      .remove()
+      .then(removeCircular);
+  }
+}

--- a/src/services/chat/token.js
+++ b/src/services/chat/token.js
@@ -1,0 +1,61 @@
+import Twilio from 'twilio';
+
+const AccessToken = Twilio.jwt.AccessToken;
+const ChatGrant = AccessToken.ChatGrant;
+
+export default class TwilioChatToken {
+  constructor(options = {}) {
+    if (!options.accountSid) {
+      throw new Error('Twilio `accountSid` needs to be provided');
+    }
+
+    if (!options.authToken) {
+      throw new Error('Twilio `authToken` needs to be provided');
+    }
+
+    if (!options.serviceSid) {
+      throw new Error('Twilio `serviceSid` needs to be provided');
+    }
+
+    if (!options.signingKeySid) {
+      throw new Error('Twilio `signingKeySid` needs to be provided');
+    }
+
+    if (!options.signingKeySecret) {
+      throw new Error('Twilio `signingKeySid` needs to be provided');
+    }
+
+    if (!options.appName) {
+      throw new Error('An `appName` needs to be provided');
+    }
+
+    this.options = options;
+  }
+
+  create(data) {
+    const { identity, device } = data;
+    const appName = this.options.appName;
+    const endpointId = `${appName}:${identity}:${device}`;
+
+    const token = new AccessToken(
+      this.options.accountSid,
+      this.options.signingKeySid,
+      this.options.signingKeySecret,
+      { ttl: this.options.ttl || 3600 * 24 }
+    );
+
+    const chatGrant = new ChatGrant({
+      serviceSid: this.options.serviceSid,
+      endpointId
+    });
+
+    token.addGrant(chatGrant);
+    token.identity = identity;
+
+    return Promise.resolve({
+      identity,
+      device,
+      token: token.toJwt()
+    });
+  }
+}

--- a/src/services/chat/users.js
+++ b/src/services/chat/users.js
@@ -1,0 +1,61 @@
+import Twilio from 'twilio';
+import removeCircular from '../utils/removeCircular';
+
+export default class TwilioChatUsers {
+  constructor(options = {}) {
+    if (!options.accountSid) {
+      throw new Error('Twilio `accountSid` needs to be provided');
+    }
+
+    if (!options.authToken) {
+      throw new Error('Twilio `authToken` needs to be provided');
+    }
+
+    if (!options.serviceSid) {
+      throw new Error('Twilio `serviceSid` needs to be provided');
+    }
+
+    this.options = options;
+
+    const twilio = new Twilio(options.accountSid, options.authToken);
+    this.client = twilio.chat.services(options.serviceSid);
+  }
+
+  find() {
+    return this.client.users.list(this.options.paginate).then(removeCircular);
+  }
+
+  get(id) {
+    return this.client
+      .users(id)
+      .fetch()
+      .then(removeCircular);
+  }
+
+  create(data) {
+    const { identity, friendlyName, attributes, roleSid } = data;
+    return this.client.users
+      .create({
+        identity,
+        friendlyName,
+        attributes,
+        roleSid
+      })
+      .then(removeCircular);
+  }
+
+  patch(id, data) {
+    const { uniqueName, friendlyName, attributes } = data;
+    return this.client
+      .users(id)
+      .update({ uniqueName, friendlyName, attributes })
+      .then(removeCircular);
+  }
+
+  remove(id) {
+    return this.client
+      .users(id)
+      .remove()
+      .then(removeCircular);
+  }
+}

--- a/src/services/utils/removeCircular.js
+++ b/src/services/utils/removeCircular.js
@@ -1,0 +1,17 @@
+const dangerous = ['_version', '_context', '_solution'];
+
+const omit = data => {
+  const newData = Object.assign({}, data);
+  dangerous.forEach(key => {
+    delete newData[key];
+  });
+  return newData;
+};
+
+export default data => {
+  if (typeof data === 'Array') {
+    return { data: data.map(omit) };
+  } else {
+    return omit(data);
+  }
+};


### PR DESCRIPTION
Very experimental right now, and breaks the existing sms and call service. Putting it here because I want to start on it and take my time with it. 

Not using voice or sms right now, but planning on using them soon. So will take over migrating them to the latest client as well.

Also want to start a discussion on the architecture design. Like I saw on feathers-stripe a stripe client was being generated for each of the different service, and this is what I'm doing here, instantiating a new twilio instance for each sub service. 

Where as I feel there should be one twilio client instantiated and then it gets passed to each service, but then maybe you can't pick and choose which service you want and which you don't.

What I find as the ideal plugin is
```
app.configure(twilio({
  ...creds,
  ...servicePathNames
}))
```
And within the opts you mention which all services you want and where you should mount them. Rather than configuring each app separately. Which is what I've actually written in the example.

You could also have both options available as well, if you pass a twilio instance in the options then it will use that, or else it will ask for credentials.