### PR TITLE
Simple update

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
-  "plugins": ["add-module-exports"],
-  "presets": [ "es2015" ]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry"
+      }
+    ]
+  ],
+  "plugins": ["add-module-exports"]
 }

--- a/example/app.js
+++ b/example/app.js
@@ -1,27 +1,33 @@
-const feathers = require('feathers');
-const rest = require('feathers-rest');
-const socketio = require('feathers-socketio');
-const bodyParser = require('body-parser');
-const errorHandler = require('feathers-errors/handler');
 const smsService = require('../lib').sms;
+const express = require('@feathersjs/express');
+const feathers = require('@feathersjs/feathers');
+const socketio = require('@feathersjs/socketio');
+const errorHandler = require('@feathersjs/errors/handler');
 
 // Create a feathers instance.
-var app = feathers()
-// Enable REST services
-  .configure(rest())
+const app = express(feathers());
+
+app
+  // Enable REST services
+  .configure(express.rest())
   // Enable Socket.io services
   .configure(socketio())
   // Turn on JSON parser for REST services
-  .use(bodyParser.json())
+  .use(express.json())
   // Turn on URL-encoded parser for REST services
-  .use(bodyParser.urlencoded({extended: true}));
+  .use(express.urlencoded({ extended: true }));
 
-app.use('/twilio/sms', smsService({
-  accountSid: 'your acount sid',
-  authToken: 'your auth token' // ex. your.domain.com
-}));
+app.use(
+  '/twilio/sms',
+  smsService({
+    accountSid: 'your acount sid',
+    authToken: 'your auth token'
+  })
+);
 
-// Send an email!
+app.use(errorHandler());
+
+// Send a text message!
 app.service('twilio/sms').create({
   from: '+15005550006', // Your Twilio SMS capable phone number
   to: '+15551234567',
@@ -31,8 +37,6 @@ app.service('twilio/sms').create({
 }).catch(err => {
   console.log(err);
 });
-
-app.use(errorHandler());
 
 // Start the server.
 const port = 3030;

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,2 +1,2 @@
 --recursive test/
---compilers js:babel-core/register
+--require @babel/register

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
   "name": "feathers-twilio",
-  "description": "Feathers Twilio Service",
   "version": "0.1.1",
+  "description": "Feathers Twilio Service",
+  "keywords": [
+    "REST",
+    "Socket.io",
+    "feathers",
+    "feathers-plugin",
+    "realtime",
+    "service",
+    "twilio"
+  ],
   "homepage": "https://github.com/feathersjs/feathers-twilio",
+  "bugs": {
+    "url": "https://github.com/feathersjs/feathers-twilio/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/feathersjs/feathers-twilio.git"
   },
-  "bugs": {
-    "url": "https://github.com/feathersjs/feathers-twilio/issues"
-  },
   "license": "MIT",
-  "keywords": [
-    "feathers",
-    "feathers-plugin",
-    "REST",
-    "Socket.io",
-    "realtime",
-    "twilio",
-    "service"
-  ],
   "author": "Feathers <hello@feathersjs.com> (http://feathersjs.com)",
   "contributors": [
     "Cory Smith <cory.m.smith@gmail.com> (https://github.com/corymsmith)",
@@ -29,18 +29,45 @@
   ],
   "main": "lib/",
   "scripts": {
-    "prepublish": "npm run compile",
-    "publish": "git push origin && git push origin --tags",
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish",
     "compile": "rimraf lib/ && babel -d lib/ src/",
-    "watch": "babel --watch -d lib/ src/",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "lint": "eslint-if-supported semistandard --fix",
     "mocha": "mocha --opts mocha.opts",
-    "test": "npm run compile && npm run lint && npm run coverage && nsp check",
+    "prepublish": "npm run compile",
+    "publish": "git push origin && git push origin --tags",
+    "release:major": "npm version major && npm publish",
+    "release:minor": "npm version minor && npm publish",
+    "release:patch": "npm version patch && npm publish",
     "start": "node example/app",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts"
+    "test": "npm run compile && npm run lint && npm run coverage && nsp check",
+    "watch": "babel --watch -d lib/ src/"
+  },
+  "dependencies": {
+    "@babel/polyfill": "^7.2.5",
+    "@feathersjs/errors": "^3.3.5",
+    "twilio": "^3.26.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.2.2",
+    "@babel/preset-env": "^7.2.3",
+    "@babel/register": "^7.0.0",
+    "@feathersjs/express": "^1.3.0",
+    "@feathersjs/feathers": "^3.1.7",
+    "@feathersjs/socketio": "^3.2.7",
+    "babel-plugin-add-module-exports": "^1.0.0",
+    "chai": "^4.2.0",
+    "eslint-if-supported": "^1.0.1",
+    "istanbul": "^1.1.0-alpha.1",
+    "mocha": "^5.2.0",
+    "nsp": "^3.2.1",
+    "rimraf": "^2.5.4",
+    "semistandard": "^13.0.1",
+    "sinon": "^7.2.2",
+    "sinon-chai": "^3.3.0"
+  },
+  "engines": {
+    "node": ">= 4"
   },
   "semistandard": {
     "env": [
@@ -49,34 +76,5 @@
     "ignore": [
       "/lib"
     ]
-  },
-  "engines": {
-    "node": ">= 4"
-  },
-  "dependencies": {
-    "babel-polyfill": "^6.3.14",
-    "feathers-errors": "^2.0.1",
-    "sinon-as-promised": "^4.0.0",
-    "sinon-chai": "^2.8.0",
-    "twilio": "^2.11.0"
-  },
-  "devDependencies": {
-    "async": "^1.3.0",
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.26",
-    "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-preset-es2015": "^6.3.13",
-    "body-parser": "^1.13.2",
-    "chai": "^3.0.0",
-    "eslint-if-supported": "^1.0.1",
-    "feathers": "^2.0.0-pre.4",
-    "feathers-rest": "^1.1.1",
-    "feathers-socketio": "^1.3.3",
-    "istanbul": "^1.1.0-alpha.1",
-    "mocha": "^2.2.5",
-    "nsp": "^2.2.0",
-    "rimraf": "^2.5.4",
-    "semistandard": "^9.1.0",
-    "sinon": "^1.17.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-if (!global._babelPolyfill) { require('babel-polyfill'); }
-
 import call from './services/call';
 import sms from './services/sms';
+
+if (!global._babelPolyfill) { require('@babel/polyfill'); }
 
 export default { call, sms };

--- a/src/services/call.js
+++ b/src/services/call.js
@@ -1,5 +1,5 @@
-import errors from 'feathers-errors';
-import twilio from 'twilio';
+import Twilio from 'twilio';
+import errors from '@feathersjs/errors';
 
 class Service {
   constructor (options = {}) {
@@ -13,13 +13,13 @@ class Service {
 
     this.from = options.from || null;
     this.paginate = options.paginate || {};
-    this.twilio = twilio(options.accountSid, options.authToken);
+    this.twilio = new Twilio(options.accountSid, options.authToken);
   }
 
   find (params) {
     params = params || {};
     return new Promise((resolve, reject) => {
-      return this.twilio.calls.get().then(resolve).catch(reject);
+      return this.twilio.calls.list(params.query || {}).then(resolve).catch(reject);
     });
   }
 
@@ -29,7 +29,7 @@ class Service {
         return reject(new errors.BadRequest('`id` needs to be provided'));
       }
 
-      return this.twilio.calls(id).get().then(resolve).catch(reject);
+      return this.twilio.calls(id).fetch().then(resolve).catch(reject);
     });
   }
 

--- a/src/services/sms.js
+++ b/src/services/sms.js
@@ -1,5 +1,5 @@
-import errors from 'feathers-errors';
-import twilio from 'twilio';
+import Twilio from 'twilio';
+import errors from '@feathersjs/errors';
 
 class Service {
   constructor (options = {}) {
@@ -13,14 +13,14 @@ class Service {
 
     this.from = options.from || null;
     this.paginate = options.paginate || {};
-    this.twilio = twilio(options.accountSid, options.authToken);
+    this.twilio = new Twilio(options.accountSid, options.authToken);
   }
 
   find (params) {
     params = params || {};
     // TODO (EK): Do something with params and pagination
     return new Promise((resolve, reject) => {
-      return this.twilio.messages.get().then(resolve).catch(reject);
+      return this.twilio.messages.list(params.query || {}).then(resolve).catch(reject);
     });
   }
 
@@ -30,7 +30,7 @@ class Service {
         return reject(new errors.BadRequest('`id` needs to be provided'));
       }
 
-      return this.twilio.messages(id).get().then(resolve).catch(reject);
+      return this.twilio.messages(id).fetch().then(resolve).catch(reject);
     });
   }
 

--- a/test/call.test.js
+++ b/test/call.test.js
@@ -28,7 +28,7 @@ describe('Twilio Call Service', function () {
 
     describe('when missing authToken', () => {
       it('throws an error', () => {
-        expect(callService.bind(null, {accountSid: 'SID'})).to.throw('Twilio `authToken` needs to be provided');
+        expect(callService.bind(null, { accountSid: 'SID' })).to.throw('Twilio `authToken` needs to be provided');
       });
     });
   });
@@ -46,7 +46,7 @@ describe('Twilio Call Service', function () {
 
     describe('when missing to field', () => {
       it('throws an error', (done) => {
-        app.service('twilio/sms').create({from: '+15005550006'}).then(done).catch(err => {
+        app.service('twilio/sms').create({ from: '+15005550006' }).then(done).catch(err => {
           expect(err.code).to.equal(400);
           expect(err.message).to.equal('`to` must be specified');
           done();
@@ -56,7 +56,7 @@ describe('Twilio Call Service', function () {
 
     describe('when missing body or applicationSid field', () => {
       it('throws an error', (done) => {
-        app.service('twilio/sms').create({from: '+15005550006', to: '+15551234567'}).then(done).catch(err => {
+        app.service('twilio/sms').create({ from: '+15005550006', to: '+15551234567' }).then(done).catch(err => {
           expect(err.code).to.equal(400);
           expect(err.message).to.equal('`body` or `mediaUrl` must be specified');
           done();

--- a/test/sms.test.js
+++ b/test/sms.test.js
@@ -1,12 +1,10 @@
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-chai.use(sinonChai);
-
-require('sinon-as-promised');
 
 import testApp from './test-app';
 import { sms as smsService } from '../src';
+chai.use(sinonChai);
 
 let server;
 let app;
@@ -21,7 +19,7 @@ describe('Twilio SMS Service', function () {
 
     describe('when missing authToken', () => {
       it('throws an error', () => {
-        expect(smsService.bind(null, {accountSid: 'SID'})).to.throw('Twilio `authToken` needs to be provided');
+        expect(smsService.bind(null, { accountSid: 'SID' })).to.throw('Twilio `authToken` needs to be provided');
       });
     });
   });
@@ -53,7 +51,7 @@ describe('Twilio SMS Service', function () {
 
     describe('when missing to field', () => {
       it('throws an error', (done) => {
-        app.service('twilio/sms').create({from: '+15005550006'}).then(done).catch(err => {
+        app.service('twilio/sms').create({ from: '+15005550006' }).then(done).catch(err => {
           expect(err.code).to.equal(400);
           expect(err.message).to.equal('`to` must be specified');
           done();
@@ -63,7 +61,7 @@ describe('Twilio SMS Service', function () {
 
     describe('when missing body or mediaUrl field', () => {
       it('throws an error', (done) => {
-        app.service('twilio/sms').create({from: '+15005550006', to: '+15551234567'}).then(done).catch(err => {
+        app.service('twilio/sms').create({ from: '+15005550006', to: '+15551234567' }).then(done).catch(err => {
           expect(err.code).to.equal(400);
           expect(err.message).to.equal('`body` or `mediaUrl` must be specified');
           done();
@@ -77,7 +75,7 @@ describe('Twilio SMS Service', function () {
     beforeEach(function (done) {
       createMessage =
         sinon
-          .stub(app.service('twilio/sms').twilio.messages, 'create').resolves({sid: 1234});
+          .stub(app.service('twilio/sms').twilio.messages, 'create').resolves({ sid: 1234 });
       done();
     });
 
@@ -102,8 +100,8 @@ describe('Twilio SMS Service', function () {
       after(done => server.close(() => done()));
       describe('valid params with body', () => {
         it('sends a message via Twilio', (done) => {
-          app.service('twilio/sms').create({from: '+15005550006', to: '+15551234567', body: 'BODY'}).then(message => {
-            expect(createMessage).to.have.been.calledWith({from: '+15005550006', to: '+15551234567', body: 'BODY'});
+          app.service('twilio/sms').create({ from: '+15005550006', to: '+15551234567', body: 'BODY' }).then(message => {
+            expect(createMessage).to.have.been.calledWith({ from: '+15005550006', to: '+15551234567', body: 'BODY' });
             expect(message.sid).to.equal(1234);
             done();
           });
@@ -146,8 +144,8 @@ describe('Twilio SMS Service', function () {
       after(done => server.close(() => done()));
       describe('valid params with body', () => {
         it('sends a message via Twilio', (done) => {
-          app.service('twilio/sms').create({to: '+15551234567', body: 'BODY'}).then(message => {
-            expect(createMessage).to.have.been.calledWith({from: '+15005550006', to: '+15551234567', body: 'BODY'});
+          app.service('twilio/sms').create({ to: '+15551234567', body: 'BODY' }).then(message => {
+            expect(createMessage).to.have.been.calledWith({ from: '+15005550006', to: '+15551234567', body: 'BODY' });
             expect(message.sid).to.equal(1234);
             done();
           });
@@ -156,4 +154,3 @@ describe('Twilio SMS Service', function () {
     });
   });
 });
-

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -1,4 +1,4 @@
-const feathers = require('feathers');
+const feathers = require('@feathersjs/feathers');
 const smsService = require('../lib').sms;
 const callService = require('../lib').call;
 
@@ -6,7 +6,7 @@ const callService = require('../lib').call;
 export default function (options) {
 // Create a feathers instance with a mailer service
   var app = feathers()
-  .use('/twilio/sms', smsService(options))
-  .use('/twilio/calls', callService(options));
+    .use('/twilio/sms', smsService(options))
+    .use('/twilio/calls', callService(options));
   return app;
 }


### PR DESCRIPTION
This makes everything use the latest versions of libraries.

Testing `example/app.js` with legit credentials/numbers works but `npm test` fails:

```
> istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts



  Twilio Call Service
    1) "before all" hook
    2) "after all" hook

  Twilio SMS Service
    Initialization
      when missing accountSid key
        ✓ throws an error
      when missing authToken
        ✓ throws an error
    Validation
      3) "before all" hook
      4) "after all" hook
    Sending messages
      from field passed in with create
        5) "before all" hook
        6) "after all" hook
      from field passed in as option
        7) "before all" hook
        8) "after all" hook


  2 passing (48ms)
  8 failing
```

I updated all dependencies, including dev deps. Not sure what to do about tests not passing.